### PR TITLE
Implement method to set target charging voltage

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -538,6 +538,14 @@ void AXP192::SetGPIO0(bool State)
     Write1Byte( 0x90 , buf );
 }
 
+// Default is VOLTAGE_4200MV
+void AXP192::SetChargeVoltage(uint8_t voltage)
+{
+    uint8_t buf = Read8bit(0x33);
+    buf = (buf & ~(0x60)) | (voltage & 0x60);
+    Write1Byte(0x33, buf);
+}
+
 // Not recommend to set charge current > 100mA, since Battery is only 80mAh.
 // more then 1C charge-rate may shorten battery life-span.
 void AXP192::SetChargeCurrent(uint8_t current)

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -18,6 +18,11 @@
 #define CURRENT_630MA  (0b0110)
 #define CURRENT_700MA  (0b0111)
 
+#define VOLTAGE_4100MV (0b00 << 5)
+#define VOLTAGE_4150MV (0b01 << 5)
+#define VOLTAGE_4200MV (0b10 << 5)
+#define VOLTAGE_4360MV (0b11 << 5)
+
 class AXP192 {
 public:
     AXP192();
@@ -62,7 +67,7 @@ public:
     uint8_t GetWarningLeve(void) __attribute__((deprecated));
 
 public:
-    // void SetChargeVoltage( uint8_t );
+    void  SetChargeVoltage( uint8_t );
     void  SetChargeCurrent( uint8_t );
     float GetBatVoltage();
     float GetBatCurrent();


### PR DESCRIPTION
Implement writes to 6:5 bits of address 0x33 as per datasheet:
![image](https://user-images.githubusercontent.com/23294131/82148900-a08fb180-9887-11ea-8112-d246296be53c.png)

Implementation reads address and modifies only 6:5 bits
```
//    0x60 = 0b01100000
// ~(0x60) = 0b10011111
buf = (buf & ~(0x60)) | (voltage & 0x60);
```

Usage:
`M5.Axp.SetChargeVoltage(VOLTAGE_4360MV);`