### PR TITLE
Implement method to set ADC sample rate

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -558,6 +558,13 @@ void AXP192::SetAdcState(bool state)
     Write1Byte(0x82, state ? 0xff : 0x00);  // Enable / Disable all ADCs
 }
 
+void AXP192::SetAdcRate( uint8_t rate )
+{
+    uint8_t buf = Read8bit(0x84);
+    buf = (buf & ~(0xc0)) | (rate & 0xc0);
+    Write1Byte(0x33, buf);
+}
+
 // AXP192 have a 6 byte storage, when the power is still valid, the data will not be lost
 void AXP192::Read6BytesStorage( uint8_t *bufPtr )
 {

--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -562,7 +562,7 @@ void AXP192::SetAdcRate( uint8_t rate )
 {
     uint8_t buf = Read8bit(0x84);
     buf = (buf & ~(0xc0)) | (rate & 0xc0);
-    Write1Byte(0x33, buf);
+    Write1Byte(0x84, buf);
 }
 
 // AXP192 have a 6 byte storage, when the power is still valid, the data will not be lost

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -9,6 +9,11 @@
 #define SLEEP_MIN(us)  (((uint64_t)us) * 60L * 1000000L)
 #define SLEEP_HR(us)   (((uint64_t)us) * 60L * 60L * 1000000L)
 
+#define ADC_RATE_025HZ (0b00 << 6)
+#define ADC_RATE_050HZ (0b01 << 6)
+#define ADC_RATE_100HZ (0b10 << 6)
+#define ADC_RATE_200HZ (0b11 << 6)
+
 #define CURRENT_100MA  (0b0000)
 #define CURRENT_190MA  (0b0001)
 #define CURRENT_280MA  (0b0010)
@@ -82,6 +87,7 @@ public:
     void SetLDO3( bool State );
     void SetGPIO0( bool State );
     void SetAdcState(bool State);
+    void SetAdcRate( uint8_t rate );
     
     // -- Power Off
     void PowerOff();


### PR DESCRIPTION
Implement writes to 7:6 bits of address 0x84 as per datasheet:
![image](https://user-images.githubusercontent.com/23294131/82150873-1bf36200-988c-11ea-9426-109d3f610233.png)

Implementation reads address and modifies only 7:6 bits

```
//    0xc0 = 0b11000000
// ~(0xc0) = 0b00111111
buf = (buf & ~(0xc0)) | (rate & 0xc0);
```

Usage:
`M5.Axp.SetAdcRate(ADC_RATE_025HZ); // default is ADC_RATE_200HZ`