### PR TITLE
Add set cutoff voltage method

### DIFF
--- a/src/AXP192.cpp
+++ b/src/AXP192.cpp
@@ -555,6 +555,12 @@ void AXP192::SetChargeCurrent(uint8_t current)
     Write1Byte(0x33, buf);
 }
 
+// Set power off voltage
+void AXP192::SetVOff( uint8_t voltage )
+{
+    Write1Byte(0x31 , (Read8bit(0x31) & 0xf8) | voltage);
+}
+
 // Cut all power, except for LDO1 (RTC)
 void AXP192::PowerOff()
 {

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -28,6 +28,16 @@
 #define VOLTAGE_4200MV (0b10 << 5)
 #define VOLTAGE_4360MV (0b11 << 5)
 
+
+#define VOLTAGE_OFF_2600MV (0b000)
+#define VOLTAGE_OFF_2700MV (0b001)
+#define VOLTAGE_OFF_2800MV (0b010)
+#define VOLTAGE_OFF_2900MV (0b011)
+#define VOLTAGE_OFF_3000MV (0b100)
+#define VOLTAGE_OFF_3100MV (0b101)
+#define VOLTAGE_OFF_3200MV (0b110)
+#define VOLTAGE_OFF_3300MV (0b111)
+
 class AXP192 {
 public:
     AXP192();
@@ -74,6 +84,7 @@ public:
 public:
     void  SetChargeVoltage( uint8_t );
     void  SetChargeCurrent( uint8_t );
+    void  SetVOff( uint8_t voltage );
     float GetBatVoltage();
     float GetBatCurrent();
     float GetVinVoltage();

--- a/src/AXP192.h
+++ b/src/AXP192.h
@@ -28,7 +28,6 @@
 #define VOLTAGE_4200MV (0b10 << 5)
 #define VOLTAGE_4360MV (0b11 << 5)
 
-
 #define VOLTAGE_OFF_2600MV (0b000)
 #define VOLTAGE_OFF_2700MV (0b001)
 #define VOLTAGE_OFF_2800MV (0b010)


### PR DESCRIPTION
Implement SetVOff method for AXP192 to set cutoff voltage and pre-define VOff voltages.

![image](https://user-images.githubusercontent.com/23294131/82679130-55a5dd80-9c7d-11ea-9fff-c6aba11b75c1.png)
